### PR TITLE
Add basic tests and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Brian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,17 @@ python interface.py
 
 You will be prompted to choose a function and provide the required input values.
 The program then prints the calculated probabilities.
+
+## Running Tests
+
+Unit tests for the probability functions are provided using `pytest`.
+Run them from the repository root with:
+
+```bash
+pytest
+```
+
+## License
+
+This project is licensed under the terms of the MIT License. See the
+[LICENSE](LICENSE) file for details.

--- a/tests/test_probability_functions.py
+++ b/tests/test_probability_functions.py
@@ -1,0 +1,38 @@
+import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import math
+import probability_functions as pf
+
+
+def test_logistic_sigmoid_zero():
+    assert pf.logistic_sigmoid(0) == 0.5
+
+
+def test_logistic_sigmoid_values():
+    assert math.isclose(pf.logistic_sigmoid(1), 0.7310585786300049, rel_tol=1e-9)
+    assert math.isclose(pf.logistic_sigmoid(-1), 0.2689414213699951, rel_tol=1e-9)
+
+
+def test_softmax_basic():
+    data = [1.0, 2.0, 3.0]
+    res = pf.softmax(data)
+    exps = [math.exp(x - 3.0) for x in data]
+    expected = [e / sum(exps) for e in exps]
+    assert all(math.isclose(a, b, rel_tol=1e-9) for a, b in zip(res, expected))
+
+
+def test_softmax_empty():
+    assert pf.softmax([]) == []
+
+
+def test_gaussian_pdf_standard_normal():
+    result = pf.gaussian_pdf(0.0)
+    expected = 1.0 / math.sqrt(2.0 * math.pi)
+    assert math.isclose(result, expected, rel_tol=1e-9)
+
+
+def test_gaussian_pdf_symmetry():
+    assert math.isclose(
+        pf.gaussian_pdf(0.5, mu=0.0, sigma=1.0),
+        pf.gaussian_pdf(-0.5, mu=0.0, sigma=1.0),
+        rel_tol=1e-9,
+    )


### PR DESCRIPTION
## Summary
- add MIT license
- expand README with testing instructions
- implement unit tests for probability functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a1306f044832fbb0bf35c4a2a83d2