### PR TITLE
v0.3.1: packaging, CLI entrypoint, docs, and stable softplus

### DIFF
--- a/.agentignore
+++ b/.agentignore
@@ -1,0 +1,55 @@
+# Files and directories AI agents should ignore by default
+# Mirrors most of .claudeignore with a few generic additions
+
+# Environments and installed packages
+venv/
+.venv/
+env/
+ENV/
+site-packages/
+__pycache__/
+*.py[cod]
+
+# Build and dist
+build/
+dist/
+*.egg-info/
+.pip-wheel-metadata/
+
+# Large data/models
+data/
+models/
+checkpoints/
+logs/
+*.pkl
+*.pickle
+*.joblib
+*.h5
+*.hdf5
+*.parquet
+*.csv
+*.json
+*.xlsx
+
+# Caches
+.cache/
+.hypothesis/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.black/
+
+# IDE/OS
+.vscode/
+.idea/
+.DS_Store
+Thumbs.db
+$Temp/
+
+# Secrets
+.env
+.env.*
+secrets.json
+config.local.py
+*.key
+*.pem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, chore/**, feat/** ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Lint and type check
+        run: |
+          black --check .
+          mypy . || true
+      - name: Run tests (pytest)
+        run: pytest -q
+      - name: Run tests (script)
+        run: python tests.py

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ wheels/
 pip-wheel-metadata/
 share/python-wheels/
 *.egg-info/
+.egg-info/
+*.egg-info/*
 .installed.cfg
 *.egg
 MANIFEST
@@ -109,6 +111,9 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Editable install metadata
+p_functions.egg-info/
 
 # Spyder project settings
 .spyderproject

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,9 @@ python tests.py
 # Test specific function families
 python sigmoid.py    # Benchmark sigmoid variants
 python relu.py       # Benchmark ReLU variants
+
+# Or with pytest
+pytest
 ```
 
 ### Code Quality
@@ -63,7 +66,13 @@ p-functions
 - **Test coverage** is assertion-based with mathematical validation (not pytest framework)
 
 ### Import Patterns  
-The project uses relative imports between modules. When adding new functions:
+Preference is to import from the package when installed:
+- `from p_functions import probability_functions as pf`
+
+When running from the repo root, direct module imports also work:
+- `import probability_functions as pf`
+
+When adding new functions:
 - Core probability functions go in `probability_functions.py`
 - Sigmoid variants and comparisons go in `sigmoid.py`
 - ReLU family functions go in `relu.py`

--- a/README.md
+++ b/README.md
@@ -31,9 +31,15 @@ Comprehensive utilities for experimenting with probability-related functions and
 python interface.py
 ```
 
+Or after install (editable or wheel):
+```bash
+p-functions
+```
+
 ### Direct Usage
 ```python
-import probability_functions as pf
+# When installed as a package
+from p_functions import probability_functions as pf
 
 # Sigmoid activation
 result = pf.logistic_sigmoid(2.5)

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,10 @@
+"""p_functions package.
+
+This package bundles probability and activation functions along with a CLI.
+"""
+
+__all__ = [
+    "probability_functions",
+    "sigmoid",
+    "relu",
+]

--- a/interface.py
+++ b/interface.py
@@ -11,7 +11,9 @@ except Exception:  # pragma: no cover
     import probability_functions as pf  # type: ignore
 
 
-def get_float(prompt: str, min_val: Optional[float] = None, max_val: Optional[float] = None) -> float:
+def get_float(
+    prompt: str, min_val: Optional[float] = None, max_val: Optional[float] = None
+) -> float:
     """Get a float input with optional validation bounds."""
     while True:
         try:
@@ -39,7 +41,7 @@ def main() -> None:
     print("3. Gaussian PDF (normal distribution)")
     print("4. Exit")
     print("=" * 35)
-    
+
     try:
         choice = input("Select an option (1-4): ").strip()
     except (KeyboardInterrupt, EOFError):
@@ -54,7 +56,9 @@ def main() -> None:
     elif choice == "2":
         values_str = input("Enter comma-separated values: ")
         try:
-            values: List[float] = [float(v.strip()) for v in values_str.split(',') if v.strip()]
+            values: List[float] = [
+                float(v.strip()) for v in values_str.split(",") if v.strip()
+            ]
             if not values:
                 print("❌ No valid numbers provided.")
                 return
@@ -63,14 +67,16 @@ def main() -> None:
         except ValueError:
             print("❌ Invalid input; please provide numbers separated by commas.")
             return
-        
+
         result = pf.softmax(values)
         print(f"Softmax({values}) = {[round(r, 6) for r in result]}")
         print(f"Sum check: {sum(result):.6f} (should be 1.0)")
     elif choice == "3":
         x = get_float("Value x: ")
         mu = get_float("Mean (mu): ")
-        sigma = get_float("Standard deviation (sigma): ", min_val=0.001)  # Prevent division by zero
+        sigma = get_float(
+            "Standard deviation (sigma): ", min_val=0.001
+        )  # Prevent division by zero
         result = pf.gaussian_pdf(x, mu, sigma)
         print(f"Gaussian PDF({x}, μ={mu}, σ={sigma}) = {result:.6f}")
     elif choice == "4":

--- a/interface.py
+++ b/interface.py
@@ -3,7 +3,12 @@
 from typing import List, Optional
 import sys
 
-import probability_functions as pf
+# Support both "installed package" (p_functions.probability_functions)
+# and "repo root execution" (plain probability_functions on PYTHONPATH)
+try:  # pragma: no cover - simple import fallback
+    from p_functions import probability_functions as pf  # type: ignore
+except Exception:  # pragma: no cover
+    import probability_functions as pf  # type: ignore
 
 
 def get_float(prompt: str, min_val: Optional[float] = None, max_val: Optional[float] = None) -> float:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,6 @@ dev = [
     "black>=22.0",
     "isort>=5.0",
 ]
-api = [
-    "anthropic>=0.60.0",
-    "pydantic>=2.11.7",
-]
 
 [project.urls]
 Homepage = "https://github.com/bshepp/p_functions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "p_functions"
-version = "0.3.0"
+version = "0.3.1"
 description = "Utilities for experimenting with probability-related functions used in machine learning"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,12 @@ api = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/username/p_functions"
-Repository = "https://github.com/username/p_functions.git"
-Issues = "https://github.com/username/p_functions/issues"
+Homepage = "https://github.com/bshepp/p_functions"
+Repository = "https://github.com/bshepp/p_functions.git"
+Issues = "https://github.com/bshepp/p_functions/issues"
 
 [project.scripts]
-p-functions = "interface:main"
+p-functions = "p_functions.interface:main"
 
 [tool.setuptools]
 packages = ["p_functions"]

--- a/relu.py
+++ b/relu.py
@@ -5,12 +5,20 @@ import timeit
 #https://en.wikipedia.org/wiki/Rectifier_(neural_networks)
 
 def soft_plus(x: float = 1.0) -> float:
-    """Softplus function: ln(1 + exp(x))"""
-    return math.log(1 + math.exp(x))
+    """Softplus function with numerical stability.
+
+    Uses the stable identity: softplus(x) = log1p(exp(-|x|)) + max(x, 0)
+    """
+    return math.log1p(math.exp(-abs(x))) + (x if x > 0 else 0.0)
 
 def soft_plus_sharpness(x: float = 1.0, beta: float = 1.0) -> float:
-    """Softplus with sharpness parameter: (1/beta) * ln(1 + exp(beta*x))"""
-    return (1 / beta) * math.log(1 + math.exp(beta * x))
+    """Softplus with sharpness parameter, numerically stable.
+
+    Stable identity: (1/β) * [log1p(exp(-β|x|)) + max(βx, 0)]
+    """
+    if beta <= 0:
+        raise ValueError("beta must be positive")
+    return (math.log1p(math.exp(-beta * abs(x))) + max(beta * x, 0.0)) / beta
 
 def swish(x: float = 1.0) -> float:
     """Swish activation function: x * sigmoid(x) = x / (1 + exp(-x))"""

--- a/relu.py
+++ b/relu.py
@@ -1,8 +1,9 @@
 import math
 import timeit
 
-#Based on the equation from
-#https://en.wikipedia.org/wiki/Rectifier_(neural_networks)
+# Based on the equation from
+# https://en.wikipedia.org/wiki/Rectifier_(neural_networks)
+
 
 def soft_plus(x: float = 1.0) -> float:
     """Softplus function with numerical stability.
@@ -10,6 +11,7 @@ def soft_plus(x: float = 1.0) -> float:
     Uses the stable identity: softplus(x) = log1p(exp(-|x|)) + max(x, 0)
     """
     return math.log1p(math.exp(-abs(x))) + (x if x > 0 else 0.0)
+
 
 def soft_plus_sharpness(x: float = 1.0, beta: float = 1.0) -> float:
     """Softplus with sharpness parameter, numerically stable.
@@ -20,42 +22,53 @@ def soft_plus_sharpness(x: float = 1.0, beta: float = 1.0) -> float:
         raise ValueError("beta must be positive")
     return (math.log1p(math.exp(-beta * abs(x))) + max(beta * x, 0.0)) / beta
 
+
 def swish(x: float = 1.0) -> float:
     """Swish activation function: x * sigmoid(x) = x / (1 + exp(-x))"""
     return x / (1 + math.exp(-x))
+
 
 def gaussian_error_linear_unit(x: float = 1.0) -> float:
     """GELU approximation: 0.5 * x * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x^3)))"""
     return 0.5 * x * (1 + math.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * x**3)))
 
+
 def noisy_relu(x: float = 1.0, noise: float = 0.0) -> float:
     """Noisy ReLU: max(0, x + N(0, σ)) - simplified without actual noise"""
     return max(0, x + noise)
+
 
 def leaky_relu(x: float = 1.0, alpha: float = 0.01) -> float:
     """Leaky ReLU: max(αx, x) where α is small positive constant"""
     return max(alpha * x, x)
 
+
 def parametric_relu(x: float = 1.0, alpha: float = 0.25) -> float:
     """Parametric ReLU: max(αx, x) where α is learnable parameter"""
     return max(alpha * x, x)
+
 
 def exponential_linear_unit(x: float = 1.0, alpha: float = 1.0) -> float:
     """ELU: x if x > 0, else α(exp(x) - 1)"""
     return x if x > 0 else alpha * (math.exp(x) - 1)
 
+
 def relu(x: float = 1.0) -> float:
     """Standard ReLU: max(0, x)"""
     return max(0, x)
 
+
 if __name__ == "__main__":
     print("Answer for the softplus implementation:", soft_plus())
-    print(timeit.timeit(soft_plus, number = 10000), "sec per loop")
+    print(timeit.timeit(soft_plus, number=10000), "sec per loop")
     print("Answer for the soft_plus_sharpness implementation:", soft_plus_sharpness())
     print(timeit.timeit(soft_plus_sharpness, number=10000), "sec per loop")
     print("Answer for the swish implementation:", swish())
     print(timeit.timeit(swish, number=10000), "sec per loop")
-    print("Answer for the gaussian_error_linear_unit implementation:", gaussian_error_linear_unit())
+    print(
+        "Answer for the gaussian_error_linear_unit implementation:",
+        gaussian_error_linear_unit(),
+    )
     print(timeit.timeit(gaussian_error_linear_unit, number=10000), "sec per loop")
     print("Answer for the noisy_relu implementation:", noisy_relu())
     print(timeit.timeit(noisy_relu, number=10000), "sec per loop")
@@ -63,7 +76,10 @@ if __name__ == "__main__":
     print(timeit.timeit(leaky_relu, number=10000), "sec per loop")
     print("Answer for the parametric_relu implementation:", parametric_relu())
     print(timeit.timeit(parametric_relu, number=10000), "sec per loop")
-    print("Answer for the exponential_linear_unit implementation:", exponential_linear_unit())
+    print(
+        "Answer for the exponential_linear_unit implementation:",
+        exponential_linear_unit(),
+    )
     print(timeit.timeit(exponential_linear_unit, number=10000), "sec per loop")
     print("Answer for the relu implementation:", relu())
     print(timeit.timeit(relu, number=10000), "sec per loop")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,24 +2,5 @@
 numpy==2.3.2
 scipy==1.16.0
 
-# Testing
+# Testing (optional)
 pytest
-
-# API and data validation (optional)
-anthropic==0.61.0
-pydantic==2.11.7
-
-# Runtime dependencies
-annotated-types==0.7.0
-anyio==4.10.0
-certifi==2025.8.3
-distro==1.9.0
-h11==0.16.0
-httpcore==1.0.9
-httpx==0.28.1
-idna==3.10
-jiter==0.10.0
-pydantic_core==2.33.2
-sniffio==1.3.1
-typing_extensions==4.14.1
-typing-inspection==0.4.1

--- a/sigmoid.py
+++ b/sigmoid.py
@@ -4,55 +4,74 @@ import scipy.stats
 import scipy.special
 import timeit
 
-#Based on the equations from
-#https://en.wikipedia.org/wiki/Sigmoid_function
+# Based on the equations from
+# https://en.wikipedia.org/wiki/Sigmoid_function
+
 
 def math_sig():
-    x=1
-    math_sig_exp = 1/(1+math.exp(-x))
+    x = 1
+    math_sig_exp = 1 / (1 + math.exp(-x))
     return math_sig_exp
 
+
 def numpy_sig():
-    x=1
+    x = 1
     numpy_sig = 1 / (1 + numpy.exp(-x))
     return numpy_sig
 
+
 def scipy_stats_logistics():
-    x=1
+    x = 1
     scipy_stats_logistics_cdf = scipy.stats.logistic.cdf(x)
     return scipy_stats_logistics_cdf
 
+
 def scipy_special():
-    x=1
+    x = 1
     scipy_special_expit = scipy.special.expit(x)
     return scipy_special_expit
 
+
 def hyperbolic_tangent_tanh():
-    x=1
+    x = 1
     hyperbolic_tangent_th = math.tanh(x)
     return hyperbolic_tangent_th
 
+
 def hyperbolic_tangent_exp():
-    x=1
+    x = 1
     hyperbolic_tangent_e = (math.exp(x) - math.exp(-x)) / ((math.exp(x) + math.exp(-x)))
     return hyperbolic_tangent_e
 
+
 def arc_tangent():
-    x=1
+    x = 1
     at = math.atan(x)
     return at
+
 
 def gudermannian(x: float = 1.0) -> float:
     """Gudermannian function: gd(x) = 2*arctan(tanh(x/2))"""
     return 2 * math.atan(math.tanh(x / 2))
 
+
 def error_function(x: float = 1.0) -> float:
     """Error function approximation using tanh: erf(x) ≈ tanh(1.2*x)"""
     return math.tanh(1.2 * x)
 
-def generalised_logistic_function(x: float = 1.0, A: float = 0.0, K: float = 1.0, B: float = 1.0, Q: float = 1.0, C: float = 1.0, M: float = 0.0) -> float:
+
+def generalised_logistic_function(
+    x: float = 1.0,
+    A: float = 0.0,
+    K: float = 1.0,
+    B: float = 1.0,
+    Q: float = 1.0,
+    C: float = 1.0,
+    M: float = 0.0,
+) -> float:
     """Generalized logistic function: A + (K-A) / (C + Q*exp(-B*(x-M)))^(1/C)"""
     return A + (K - A) / ((C + Q * math.exp(-B * (x - M))) ** (1 / C))
+
 
 def smooth_step(x: float = 1.0) -> float:
     """Smooth step function: 3x² - 2x³ for x ∈ [0,1], clamped elsewhere"""
@@ -62,15 +81,17 @@ def smooth_step(x: float = 1.0) -> float:
         return 1.0
     return 3 * x * x - 2 * x * x * x
 
+
 def algebraic_sigmoid(x: float = 1.0) -> float:
     """Algebraic sigmoid: x / sqrt(1 + x²)"""
     return x / math.sqrt(1 + x * x)
 
+
 if __name__ == "__main__":
     print("Answer math.exp Module:", math_sig())
-    print(timeit.timeit(math_sig, number = 10000))
+    print(timeit.timeit(math_sig, number=10000))
     print("Answer numpy_sig Module:", numpy_sig())
-    print(timeit.timeit(numpy_sig, number = 10000))
+    print(timeit.timeit(numpy_sig, number=10000))
     print("Answer scipy.stats.logistics.cdf Module:", scipy_stats_logistics())
     print(timeit.timeit(scipy_stats_logistics, number=10000))
     print("Answer scipy.special.expit Module:", scipy_special())

--- a/tests.py
+++ b/tests.py
@@ -19,81 +19,89 @@ import relu
 def test_probability_functions():
     """Test core probability functions."""
     print("🧪 Testing probability_functions.py...")
-    
+
     # Test logistic sigmoid
     assert abs(pf.logistic_sigmoid(0) - 0.5) < 1e-10, "Sigmoid(0) should be 0.5"
-    assert abs(pf.logistic_sigmoid(1000) - 1.0) < 1e-3, "Sigmoid(large) should approach 1.0"
-    
+    assert (
+        abs(pf.logistic_sigmoid(1000) - 1.0) < 1e-3
+    ), "Sigmoid(large) should approach 1.0"
+
     # Test softmax
     result = pf.softmax([1, 2, 3])
     assert abs(sum(result) - 1.0) < 1e-10, "Softmax should sum to 1.0"
     assert len(result) == 3, "Softmax should preserve input length"
-    
+
     # Test empty softmax
     assert pf.softmax([]) == [], "Empty softmax should return empty list"
-    
+
     # Test gaussian PDF
     pdf_val = pf.gaussian_pdf(0, 0, 1)  # Standard normal at mean
     expected = 1.0 / math.sqrt(2 * math.pi)
-    assert abs(pdf_val - expected) < 1e-10, f"Standard normal PDF(0) should be {expected}"
-    
+    assert (
+        abs(pdf_val - expected) < 1e-10
+    ), f"Standard normal PDF(0) should be {expected}"
+
     print("✅ probability_functions.py tests passed!")
 
 
 def test_sigmoid_functions():
     """Test sigmoid activation functions."""
     print("🧪 Testing sigmoid.py...")
-    
+
     # Test implemented functions don't crash
     functions_to_test = [
-        ('gudermannian', sigmoid.gudermannian),
-        ('error_function', sigmoid.error_function),
-        ('smooth_step', sigmoid.smooth_step),
-        ('algebraic_sigmoid', sigmoid.algebraic_sigmoid),
+        ("gudermannian", sigmoid.gudermannian),
+        ("error_function", sigmoid.error_function),
+        ("smooth_step", sigmoid.smooth_step),
+        ("algebraic_sigmoid", sigmoid.algebraic_sigmoid),
     ]
-    
+
     for name, func in functions_to_test:
         try:
             result = func(1.0)
-            assert isinstance(result, (int, float)), f"{name} should return numeric value"
+            assert isinstance(
+                result, (int, float)
+            ), f"{name} should return numeric value"
             print(f"  ✅ {name}(1.0) = {result:.6f}")
         except Exception as e:
             print(f"  ❌ {name} failed: {e}")
-            
+
     # Test smooth step bounds
     assert sigmoid.smooth_step(-1) == 0.0, "Smooth step should be 0 for x <= 0"
     assert sigmoid.smooth_step(2) == 1.0, "Smooth step should be 1 for x >= 1"
-    
+
     print("✅ sigmoid.py tests passed!")
 
 
 def test_relu_functions():
     """Test ReLU activation functions."""
     print("🧪 Testing relu.py...")
-    
+
     functions_to_test = [
-        ('soft_plus', relu.soft_plus),
-        ('swish', relu.swish),
-        ('gaussian_error_linear_unit', relu.gaussian_error_linear_unit),
-        ('leaky_relu', relu.leaky_relu),
-        ('relu', relu.relu),
+        ("soft_plus", relu.soft_plus),
+        ("swish", relu.swish),
+        ("gaussian_error_linear_unit", relu.gaussian_error_linear_unit),
+        ("leaky_relu", relu.leaky_relu),
+        ("relu", relu.relu),
     ]
-    
+
     for name, func in functions_to_test:
         try:
             result = func(1.0)
-            assert isinstance(result, (int, float)), f"{name} should return numeric value"
+            assert isinstance(
+                result, (int, float)
+            ), f"{name} should return numeric value"
             print(f"  ✅ {name}(1.0) = {result:.6f}")
         except Exception as e:
             print(f"  ❌ {name} failed: {e}")
-    
+
     # Test ReLU properties
     assert relu.relu(-5) == 0.0, "ReLU should be 0 for negative inputs"
     assert relu.relu(5) == 5.0, "ReLU should return input for positive values"
-    
+
     # Test leaky ReLU
     assert relu.leaky_relu(-1) == -0.01, "Leaky ReLU should allow small negative values"
-    
+
     print("✅ relu.py tests passed!")
 
 
@@ -101,16 +109,16 @@ def run_all_tests():
     """Run all test suites."""
     print("🚀 Starting comprehensive test suite...")
     print("=" * 50)
-    
+
     try:
         test_probability_functions()
         test_sigmoid_functions()
         test_relu_functions()
-        
+
         print("=" * 50)
         print("🎉 All tests passed successfully!")
         return True
-        
+
     except AssertionError as e:
         print(f"❌ Test failed: {e}")
         return False

--- a/tests.py
+++ b/tests.py
@@ -8,7 +8,10 @@ import os
 # Add project root to path for imports
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-import probability_functions as pf
+try:
+    from p_functions import probability_functions as pf  # type: ignore
+except Exception:
+    import probability_functions as pf  # type: ignore
 import sigmoid
 import relu
 

--- a/tests/test_probability_functions.py
+++ b/tests/test_probability_functions.py
@@ -1,7 +1,10 @@
 import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import math
 import pytest
-import probability_functions as pf
+try:
+    from p_functions import probability_functions as pf  # type: ignore
+except Exception:
+    import probability_functions as pf  # type: ignore
 
 
 def test_logistic_sigmoid_zero():

--- a/tests/test_probability_functions.py
+++ b/tests/test_probability_functions.py
@@ -1,6 +1,9 @@
-import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import sys, os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import math
 import pytest
+
 try:
     from p_functions import probability_functions as pf  # type: ignore
 except Exception:


### PR DESCRIPTION
## Summary
- Fix package installability and CLI entrypoint (`p_functions.interface:main`)
- Remove unused Anthropic/Pydantic and `api` extra
- Update README/CLAUDE: installed import path and `p-functions` usage; pytest guidance
- Stabilize `relu.soft_plus` and `soft_plus_sharpness` numerically; validate beta
- Bump version to 0.3.1

## Test plan
- Editable install: `pip install -e .` OK
- CLI: `p-functions` launches and exits
- Tests: `python tests.py` and `pytest` pass locally
- Import paths: both `from p_functions import probability_functions` and direct repo import work